### PR TITLE
[#14] 디테일 화면 기능 구현

### DIFF
--- a/data/src/main/java/io/seoj17/soop/data/model/RepoDetailDataModel.kt
+++ b/data/src/main/java/io/seoj17/soop/data/model/RepoDetailDataModel.kt
@@ -5,7 +5,8 @@ import io.seoj17.soop.data.response.RepoDetailResponse
 data class RepoDetailDataModel(
     val userThumbnailUrl: String,
     val repoName: String,
-    val startCount: Int,
+    val starCount: Int,
+    val mainLanguage: String?,
     val watcherCount: Int,
     val forkCount: Int,
     val description: String?,
@@ -15,7 +16,8 @@ fun RepoDetailResponse.toDataModel(): RepoDetailDataModel {
     return RepoDetailDataModel(
         userThumbnailUrl = owner.avatarUrl,
         repoName = name,
-        startCount = stargazersCount,
+        mainLanguage = language,
+        starCount = stargazersCount,
         watcherCount = watchersCount,
         forkCount = forksCount,
         description = description,

--- a/data/src/main/java/io/seoj17/soop/data/response/UserInfoResponse.kt
+++ b/data/src/main/java/io/seoj17/soop/data/response/UserInfoResponse.kt
@@ -12,7 +12,7 @@ data class UserInfoResponse(
     @SerialName("blog")
     val blog: String,
     @SerialName("company")
-    val company: String,
+    val company: String?,
     @SerialName("created_at")
     val createdAt: String,
     @SerialName("email")

--- a/domain/src/main/java/io/seoj17/soop/domain/model/RepoDetailDomainModel.kt
+++ b/domain/src/main/java/io/seoj17/soop/domain/model/RepoDetailDomainModel.kt
@@ -1,0 +1,25 @@
+package io.seoj17.soop.domain.model
+
+import io.seoj17.soop.data.model.RepoDetailDataModel
+
+data class RepoDetailDomainModel(
+    val userThumbnailUrl: String,
+    val repoName: String,
+    val mainLanguage: String?,
+    val starCount: Int,
+    val watcherCount: Int,
+    val forkCount: Int,
+    val description: String?,
+)
+
+fun RepoDetailDataModel.toDomainModel(): RepoDetailDomainModel {
+    return RepoDetailDomainModel(
+        userThumbnailUrl = userThumbnailUrl,
+        repoName = repoName,
+        mainLanguage = mainLanguage,
+        starCount = starCount,
+        watcherCount = watcherCount,
+        forkCount = forkCount,
+        description = description,
+    )
+}

--- a/domain/src/main/java/io/seoj17/soop/domain/model/UserDetailDomainModel.kt
+++ b/domain/src/main/java/io/seoj17/soop/domain/model/UserDetailDomainModel.kt
@@ -1,0 +1,28 @@
+package io.seoj17.soop.domain.model
+
+data class UserDetailDomainModel(
+    val userThumbnailUrl: String,
+    val userName: String,
+    val followerCount: Int,
+    val followingCount: Int,
+    val repoCount: Int,
+    val usedLanguageList: List<String>,
+    val bio: String?,
+) {
+    companion object {
+        fun toModel(
+            userInfo: UserInfoDomainModel,
+            userRepoList: List<UserRepoDomainModel>,
+        ): UserDetailDomainModel {
+            return UserDetailDomainModel(
+                userThumbnailUrl = userInfo.userThumbnailUrl,
+                userName = userInfo.userName,
+                followerCount = userInfo.followerCount,
+                followingCount = userInfo.followingCount,
+                repoCount = userRepoList.size,
+                usedLanguageList = userRepoList.mapNotNull { it.usedLanguage },
+                bio = userInfo.bio,
+            )
+        }
+    }
+}

--- a/domain/src/main/java/io/seoj17/soop/domain/model/UserInfoDomainModel.kt
+++ b/domain/src/main/java/io/seoj17/soop/domain/model/UserInfoDomainModel.kt
@@ -1,0 +1,21 @@
+package io.seoj17.soop.domain.model
+
+import io.seoj17.soop.data.model.UserInfoDataModel
+
+data class UserInfoDomainModel(
+    val userThumbnailUrl: String,
+    val userName: String,
+    val followerCount: Int,
+    val followingCount: Int,
+    val bio: String?,
+)
+
+fun UserInfoDataModel.toDomainModel(): UserInfoDomainModel {
+    return UserInfoDomainModel(
+        userThumbnailUrl = userThumbnailUrl,
+        userName = userName,
+        followerCount = followerCount,
+        followingCount = followingCount,
+        bio = bio,
+    )
+}

--- a/domain/src/main/java/io/seoj17/soop/domain/model/UserRepoDomainModel.kt
+++ b/domain/src/main/java/io/seoj17/soop/domain/model/UserRepoDomainModel.kt
@@ -1,0 +1,17 @@
+package io.seoj17.soop.domain.model
+
+import io.seoj17.soop.data.model.UserRepoDataModel
+
+data class UserRepoDomainModel(
+    val usedLanguage: String?,
+)
+
+fun UserRepoDataModel.toDomainModel(): UserRepoDomainModel {
+    return UserRepoDomainModel(
+        usedLanguage = usedLanguage,
+    )
+}
+
+fun List<UserRepoDataModel>.toDomainModel(): List<UserRepoDomainModel> {
+    return map { it.toDomainModel() }
+}

--- a/domain/src/main/java/io/seoj17/soop/domain/usecase/GetUserDetailUseCase.kt
+++ b/domain/src/main/java/io/seoj17/soop/domain/usecase/GetUserDetailUseCase.kt
@@ -1,0 +1,21 @@
+package io.seoj17.soop.domain.usecase
+
+import dagger.Reusable
+import io.seoj17.soop.domain.model.UserDetailDomainModel
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.combine
+import javax.inject.Inject
+
+@Reusable
+class GetUserDetailUseCase @Inject constructor(
+    private val getUserInfoUseCase: GetUserInfoUseCase,
+    private val getUserRepoListUseCase: GetUserRepoListUseCase,
+) {
+    operator fun invoke(userName: String): Flow<UserDetailDomainModel> {
+        val userInfoFlow = getUserInfoUseCase(userName)
+        val userRepoListFlow = getUserRepoListUseCase(userName)
+        return combine(userInfoFlow, userRepoListFlow) { userInfo, userRepoList ->
+            UserDetailDomainModel.toModel(userInfo, userRepoList)
+        }
+    }
+}

--- a/domain/src/main/java/io/seoj17/soop/domain/usecase/GetUserInfoUseCase.kt
+++ b/domain/src/main/java/io/seoj17/soop/domain/usecase/GetUserInfoUseCase.kt
@@ -1,0 +1,18 @@
+package io.seoj17.soop.domain.usecase
+
+import dagger.Reusable
+import io.seoj17.soop.data.repository.UserRepository
+import io.seoj17.soop.domain.model.UserInfoDomainModel
+import io.seoj17.soop.domain.model.toDomainModel
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flow
+import javax.inject.Inject
+
+@Reusable
+class GetUserInfoUseCase @Inject constructor(
+    private val userRepository: UserRepository,
+) {
+    operator fun invoke(userName: String): Flow<UserInfoDomainModel> {
+        return flow { emit(userRepository.getUserInfo(userName).toDomainModel()) }
+    }
+}

--- a/domain/src/main/java/io/seoj17/soop/domain/usecase/GetUserRepoDetailUseCase.kt
+++ b/domain/src/main/java/io/seoj17/soop/domain/usecase/GetUserRepoDetailUseCase.kt
@@ -1,0 +1,16 @@
+package io.seoj17.soop.domain.usecase
+
+import dagger.Reusable
+import io.seoj17.soop.data.repository.RepoRepository
+import io.seoj17.soop.domain.model.RepoDetailDomainModel
+import io.seoj17.soop.domain.model.toDomainModel
+import javax.inject.Inject
+
+@Reusable
+class GetUserRepoDetailUseCase @Inject constructor(
+    private val repoRepository: RepoRepository,
+) {
+    suspend operator fun invoke(userName: String, repoName: String): RepoDetailDomainModel {
+        return repoRepository.getRepoDetail(userName, repoName).toDomainModel()
+    }
+}

--- a/domain/src/main/java/io/seoj17/soop/domain/usecase/GetUserRepoListUseCase.kt
+++ b/domain/src/main/java/io/seoj17/soop/domain/usecase/GetUserRepoListUseCase.kt
@@ -1,0 +1,18 @@
+package io.seoj17.soop.domain.usecase
+
+import dagger.Reusable
+import io.seoj17.soop.data.repository.RepoRepository
+import io.seoj17.soop.domain.model.UserRepoDomainModel
+import io.seoj17.soop.domain.model.toDomainModel
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flow
+import javax.inject.Inject
+
+@Reusable
+class GetUserRepoListUseCase @Inject constructor(
+    private val repoRepository: RepoRepository,
+) {
+    operator fun invoke(userName: String): Flow<List<UserRepoDomainModel>> {
+        return flow { emit(repoRepository.getUserRepoList(userName).toDomainModel()) }
+    }
+}

--- a/presentation/src/main/java/io/seoj17/soop/presentation/component/SoopTextBadge.kt
+++ b/presentation/src/main/java/io/seoj17/soop/presentation/component/SoopTextBadge.kt
@@ -23,7 +23,7 @@ fun SoopTextBadge(
         modifier = modifier
             .clip(RoundedCornerShape(20.dp))
             .background(color = Color.LightGray)
-            .padding(horizontal = 8.dp, vertical = 4.dp),
+            .padding(horizontal = 8.dp, vertical = 2.dp),
         text = text,
         color = Color.Gray,
         fontSize = textSize,

--- a/presentation/src/main/java/io/seoj17/soop/presentation/navigation/SoopNavHost.kt
+++ b/presentation/src/main/java/io/seoj17/soop/presentation/navigation/SoopNavHost.kt
@@ -25,8 +25,8 @@ fun SoopNavHost(
         popEnterTransition = { EnterTransition.None },
     ) {
         searchNavigation(
-            onClickSearchResultItem = {
-                navController.navigateToSearchDetail()
+            onClickSearchResultItem = { userName, repoName ->
+                navController.navigateToSearchDetail(userName = userName, repoName = repoName)
             },
         )
         searchDetailNavigation()

--- a/presentation/src/main/java/io/seoj17/soop/presentation/navigation/SoopRoute.kt
+++ b/presentation/src/main/java/io/seoj17/soop/presentation/navigation/SoopRoute.kt
@@ -5,6 +5,8 @@ sealed interface SoopRoute {
 
     data object Search : SoopRoute {
         override val route: String = "search"
+        const val KEY_USER_NAME = "userName"
+        const val KEY_REPO_NAME = "repoName"
     }
 
     data object SearchDetail : SoopRoute {

--- a/presentation/src/main/java/io/seoj17/soop/presentation/ui/detail/SearchDetailViewModel.kt
+++ b/presentation/src/main/java/io/seoj17/soop/presentation/ui/detail/SearchDetailViewModel.kt
@@ -1,17 +1,37 @@
 package io.seoj17.soop.presentation.ui.detail
 
+import android.util.Log
 import androidx.lifecycle.SavedStateHandle
+import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
+import io.seoj17.soop.domain.usecase.GetUserDetailUseCase
+import io.seoj17.soop.domain.usecase.GetUserRepoDetailUseCase
 import io.seoj17.soop.presentation.base.BaseViewModel
+import io.seoj17.soop.presentation.navigation.SoopRoute
+import io.seoj17.soop.presentation.ui.detail.model.toUiModel
 import io.seoj17.soop.presentation.ui.detail.mvi.SearchDetailIntent
 import io.seoj17.soop.presentation.ui.detail.mvi.SearchDetailSideEffect
 import io.seoj17.soop.presentation.ui.detail.mvi.SearchDetailUiState
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.onCompletion
+import kotlinx.coroutines.flow.onStart
+import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 @HiltViewModel
 class SearchDetailViewModel @Inject constructor(
     savedStateHandle: SavedStateHandle,
+    private val getUserRepoDetailUseCase: GetUserRepoDetailUseCase,
+    private val getUserDetailUseCase: GetUserDetailUseCase,
 ) : BaseViewModel<SearchDetailUiState, SearchDetailSideEffect, SearchDetailIntent>(savedStateHandle) {
+    private val userName = savedStateHandle.get<String>(SoopRoute.Search.KEY_USER_NAME)
+    private val repoName = savedStateHandle.get<String>(SoopRoute.Search.KEY_USER_NAME)
+
+    init {
+        getRepoDetail(userName, repoName)
+        getUserDetail(userName)
+    }
+
     override fun createInitialState(savedStateHandle: SavedStateHandle): SearchDetailUiState {
         return SearchDetailUiState.initialize()
     }
@@ -28,9 +48,48 @@ class SearchDetailViewModel @Inject constructor(
         }
     }
 
+    private fun updateLoading(isLoading: Boolean) {
+        reduce {
+            copy(isLoading = isLoading)
+        }
+    }
+
     private fun updateBottomSheetVisible(visible: Boolean) {
         reduce {
             copy(isBottomSheetVisible = visible)
+        }
+    }
+
+    private fun getRepoDetail(userName: String?, repoName: String?) {
+        updateLoading(true)
+        viewModelScope.launch {
+            val repoDetail = getUserRepoDetailUseCase(
+                userName = userName.orEmpty(),
+                repoName = repoName.orEmpty(),
+            )
+            reduce {
+                copy(repoDetail = repoDetail.toUiModel())
+            }
+        }
+    }
+
+    private fun getUserDetail(userName: String?) {
+        viewModelScope.launch {
+            getUserDetailUseCase(userName = userName.orEmpty())
+                .onStart {
+                    updateLoading(true)
+                }
+                .onCompletion {
+                    updateLoading(false)
+                }
+                .map {
+                    it.toUiModel()
+                }
+                .collect { userDetailUiModel ->
+                    reduce {
+                        copy(userDetail = userDetailUiModel)
+                    }
+                }
         }
     }
 }

--- a/presentation/src/main/java/io/seoj17/soop/presentation/ui/detail/model/RepoDetail.kt
+++ b/presentation/src/main/java/io/seoj17/soop/presentation/ui/detail/model/RepoDetail.kt
@@ -1,0 +1,25 @@
+package io.seoj17.soop.presentation.ui.detail.model
+
+import io.seoj17.soop.domain.model.RepoDetailDomainModel
+
+data class RepoDetail(
+    val userThumbnailUrl: String,
+    val repoName: String,
+    val mainLanguage: String?,
+    val starCount: Int,
+    val watcherCount: Int,
+    val forkCount: Int,
+    val description: String?,
+)
+
+fun RepoDetailDomainModel.toUiModel(): RepoDetail {
+    return RepoDetail(
+        userThumbnailUrl = userThumbnailUrl,
+        repoName = repoName,
+        mainLanguage = mainLanguage,
+        starCount = starCount,
+        watcherCount = watcherCount,
+        forkCount = forkCount,
+        description = description,
+    )
+}

--- a/presentation/src/main/java/io/seoj17/soop/presentation/ui/detail/model/UserDetail.kt
+++ b/presentation/src/main/java/io/seoj17/soop/presentation/ui/detail/model/UserDetail.kt
@@ -1,0 +1,30 @@
+package io.seoj17.soop.presentation.ui.detail.model
+
+import io.seoj17.soop.domain.model.UserDetailDomainModel
+
+data class UserDetail(
+    val userThumbnailUrl: String,
+    val userName: String,
+    val followerCount: Int,
+    val followingCount: Int,
+    val repoCount: Int,
+    val usedLanguage: String,
+    val bio: String?,
+)
+
+fun UserDetailDomainModel.toUiModel(): UserDetail {
+    return UserDetail(
+        userThumbnailUrl = userThumbnailUrl,
+        userName = userName,
+        followerCount = followerCount,
+        followingCount = followingCount,
+        repoCount = repoCount,
+        usedLanguage = usedLanguageList
+            .distinct()
+            .joinToString(
+                separator = ", ",
+                transform = { it },
+            ),
+        bio = bio,
+    )
+}

--- a/presentation/src/main/java/io/seoj17/soop/presentation/ui/detail/mvi/SearchDetailUiState.kt
+++ b/presentation/src/main/java/io/seoj17/soop/presentation/ui/detail/mvi/SearchDetailUiState.kt
@@ -1,15 +1,37 @@
 package io.seoj17.soop.presentation.ui.detail.mvi
 
 import io.seoj17.soop.presentation.base.UiState
+import io.seoj17.soop.presentation.ui.detail.model.RepoDetail
+import io.seoj17.soop.presentation.ui.detail.model.UserDetail
 
 data class SearchDetailUiState(
     val isLoading: Boolean,
     val isBottomSheetVisible: Boolean,
+    val repoDetail: RepoDetail,
+    val userDetail: UserDetail,
 ) : UiState {
     companion object {
         fun initialize() = SearchDetailUiState(
             isLoading = false,
             isBottomSheetVisible = false,
+            repoDetail = RepoDetail(
+                userThumbnailUrl = "",
+                repoName = "",
+                mainLanguage = "",
+                starCount = -1,
+                watcherCount = -1,
+                forkCount = -1,
+                description = "",
+            ),
+            userDetail = UserDetail(
+                userThumbnailUrl = "",
+                userName = "",
+                followerCount = -1,
+                followingCount = -1,
+                repoCount = -1,
+                usedLanguage = "",
+                bio = "",
+            ),
         )
     }
 }

--- a/presentation/src/main/java/io/seoj17/soop/presentation/ui/detail/naviagation/SearchDetailNavigation.kt
+++ b/presentation/src/main/java/io/seoj17/soop/presentation/ui/detail/naviagation/SearchDetailNavigation.kt
@@ -2,17 +2,25 @@ package io.seoj17.soop.presentation.ui.detail.naviagation
 
 import androidx.navigation.NavController
 import androidx.navigation.NavGraphBuilder
+import androidx.navigation.NavType
 import androidx.navigation.compose.composable
+import androidx.navigation.navArgument
 import io.seoj17.soop.presentation.navigation.SoopRoute
+import io.seoj17.soop.presentation.navigation.SoopRoute.Search.KEY_REPO_NAME
+import io.seoj17.soop.presentation.navigation.SoopRoute.Search.KEY_USER_NAME
 
-fun NavController.navigateToSearchDetail() {
-    navigate(
-        SoopRoute.SearchDetail.route,
-    )
+fun NavController.navigateToSearchDetail(userName: String, repoName: String) {
+    navigate("${SoopRoute.SearchDetail.route}/$userName/$repoName")
 }
 
 fun NavGraphBuilder.searchDetailNavigation() {
-    composable(route = SoopRoute.SearchDetail.route) {
+    composable(
+        route = "${SoopRoute.SearchDetail.route}/{$KEY_USER_NAME}/{$KEY_REPO_NAME}",
+        arguments = listOf(
+            navArgument(KEY_USER_NAME) { type = NavType.StringType },
+            navArgument(KEY_REPO_NAME) { type = NavType.StringType },
+        ),
+    ) {
         SearchDetailRoute()
     }
 }

--- a/presentation/src/main/java/io/seoj17/soop/presentation/ui/detail/naviagation/SearchDetailRoute.kt
+++ b/presentation/src/main/java/io/seoj17/soop/presentation/ui/detail/naviagation/SearchDetailRoute.kt
@@ -15,11 +15,8 @@ fun SearchDetailRoute(
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
 
     SearchDetailScreen(
-        repoName = "",
-        repoLanguage = "",
-        userName = "",
-        onClickUserDetail = {},
-        isBottomSheetVisible = uiState.isBottomSheetVisible,
+        uiState = uiState,
+        onClickUserDetail = { viewModel.handleIntent(SearchDetailIntent.ClickMoreUserInfo) },
         onTouchBottomSheetClose = { viewModel.handleIntent(SearchDetailIntent.TouchBottomSheetClose) },
     )
 }

--- a/presentation/src/main/java/io/seoj17/soop/presentation/ui/search/SearchScreen.kt
+++ b/presentation/src/main/java/io/seoj17/soop/presentation/ui/search/SearchScreen.kt
@@ -38,7 +38,7 @@ import io.seoj17.soop.presentation.utils.noRippleSingleClick
 fun SearchScreen(
     uiState: SearchUiState,
     onClickSearch: (String) -> Unit,
-    onClickSearchResultItem: () -> Unit,
+    onClickSearchResultItem: (String, String) -> Unit,
 ) {
     Column(modifier = Modifier.fillMaxSize()) {
         SearchContainer(
@@ -61,14 +61,14 @@ fun SearchScreen(
 private fun SearchResultContainer(
     modifier: Modifier,
     repoList: ImmutableList<RepoInfo>,
-    onClickSearchResultItem: () -> Unit,
+    onClickSearchResultItem: (String, String) -> Unit,
 ) {
     LazyColumn(modifier = modifier) {
         itemsIndexed(repoList) { index, repoInfo ->
             RepoInfoItem(
                 modifier = Modifier
                     .fillMaxWidth()
-                    .noRippleClick { onClickSearchResultItem() }
+                    .noRippleClick { onClickSearchResultItem(repoInfo.userName, repoInfo.repoName) }
                     .padding(
                         start = 20.dp,
                         end = 20.dp,
@@ -142,7 +142,7 @@ private fun RepoPropertyContainer(modifier: Modifier, starCount: Int, mainLangua
     ) {
         SoopStar(
             modifier = Modifier.wrapContentSize(),
-            text = NumberFormater.starCount(starCount),
+            text = NumberFormater.format(starCount),
         )
         SoopMainLanguage(
             modifier = Modifier.wrapContentSize(),
@@ -156,7 +156,7 @@ private fun RepoPropertyContainer(modifier: Modifier, starCount: Int, mainLangua
 private fun SearchScreenPreview() {
     SearchScreen(
         onClickSearch = {},
-        onClickSearchResultItem = {},
+        onClickSearchResultItem = { _, _ -> },
         uiState = SearchUiState(
             isLoading = false,
             repoList = ImmutableList(

--- a/presentation/src/main/java/io/seoj17/soop/presentation/ui/search/SearchViewModel.kt
+++ b/presentation/src/main/java/io/seoj17/soop/presentation/ui/search/SearchViewModel.kt
@@ -33,7 +33,12 @@ class SearchViewModel @Inject constructor(
             }
 
             is SearchIntent.ClickSearchResultItem -> {
-                postSideEffect(SearchSideEffect.NavigateToSearchDetail)
+                postSideEffect(
+                    SearchSideEffect.NavigateToSearchDetail(
+                        userName = intent.userName,
+                        repoName = intent.repoName,
+                    ),
+                )
             }
         }
     }

--- a/presentation/src/main/java/io/seoj17/soop/presentation/ui/search/mvi/SearchIntent.kt
+++ b/presentation/src/main/java/io/seoj17/soop/presentation/ui/search/mvi/SearchIntent.kt
@@ -4,5 +4,5 @@ import io.seoj17.soop.presentation.base.UiIntent
 
 sealed interface SearchIntent : UiIntent {
     data class ClickSearch(val searchText: String) : SearchIntent
-    data object ClickSearchResultItem : SearchIntent
+    data class ClickSearchResultItem(val userName: String, val repoName: String) : SearchIntent
 }

--- a/presentation/src/main/java/io/seoj17/soop/presentation/ui/search/mvi/SearchSideEffect.kt
+++ b/presentation/src/main/java/io/seoj17/soop/presentation/ui/search/mvi/SearchSideEffect.kt
@@ -3,5 +3,5 @@ package io.seoj17.soop.presentation.ui.search.mvi
 import io.seoj17.soop.presentation.base.UiSideEffect
 
 sealed interface SearchSideEffect : UiSideEffect {
-    data object NavigateToSearchDetail : SearchSideEffect
+    data class NavigateToSearchDetail(val userName: String, val repoName: String) : SearchSideEffect
 }

--- a/presentation/src/main/java/io/seoj17/soop/presentation/ui/search/navigation/SearchNavigation.kt
+++ b/presentation/src/main/java/io/seoj17/soop/presentation/ui/search/navigation/SearchNavigation.kt
@@ -11,7 +11,7 @@ fun NavController.navigateToSearch() {
     )
 }
 
-fun NavGraphBuilder.searchNavigation(onClickSearchResultItem: () -> Unit) {
+fun NavGraphBuilder.searchNavigation(onClickSearchResultItem: (String, String) -> Unit) {
     composable(route = SoopRoute.Search.route) {
         SearchRoute(onClickSearchResultItem = onClickSearchResultItem)
     }

--- a/presentation/src/main/java/io/seoj17/soop/presentation/ui/search/navigation/SearchRoute.kt
+++ b/presentation/src/main/java/io/seoj17/soop/presentation/ui/search/navigation/SearchRoute.kt
@@ -11,13 +11,19 @@ import io.seoj17.soop.presentation.ui.search.mvi.SearchIntent
 import io.seoj17.soop.presentation.ui.search.mvi.SearchSideEffect
 
 @Composable
-fun SearchRoute(onClickSearchResultItem: () -> Unit, viewModel: SearchViewModel = hiltViewModel()) {
+fun SearchRoute(
+    onClickSearchResultItem: (String, String) -> Unit,
+    viewModel: SearchViewModel = hiltViewModel(),
+) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
 
     LaunchedEffect(viewModel.sideEffect) {
         viewModel.sideEffect.collect { sideEffect ->
             when (sideEffect) {
-                is SearchSideEffect.NavigateToSearchDetail -> onClickSearchResultItem()
+                is SearchSideEffect.NavigateToSearchDetail -> onClickSearchResultItem(
+                    sideEffect.userName,
+                    sideEffect.repoName,
+                )
             }
         }
     }
@@ -27,8 +33,13 @@ fun SearchRoute(onClickSearchResultItem: () -> Unit, viewModel: SearchViewModel 
         onClickSearch = { searchText ->
             viewModel.handleIntent(SearchIntent.ClickSearch(searchText))
         },
-        onClickSearchResultItem = {
-            viewModel.handleIntent(SearchIntent.ClickSearchResultItem)
+        onClickSearchResultItem = { userName, repoName ->
+            viewModel.handleIntent(
+                SearchIntent.ClickSearchResultItem(
+                    userName = userName,
+                    repoName = repoName,
+                ),
+            )
         },
     )
 }

--- a/presentation/src/main/java/io/seoj17/soop/presentation/utils/NumberFormater.kt
+++ b/presentation/src/main/java/io/seoj17/soop/presentation/utils/NumberFormater.kt
@@ -3,7 +3,7 @@ package io.seoj17.soop.presentation.utils
 import java.util.Locale
 
 object NumberFormater {
-    fun starCount(num: Int): String {
+    fun format(num: Int): String {
         return when {
             num < 1_000 -> {
                 num.toString()


### PR DESCRIPTION
## Issue No
- close #14 

## Overview (Required)
- 상세 화면 구현 완료했습니다.
- 특정 레포지토리 정보 가져오는 유스케이스, 유저 정보를 가져오는 유스케이스, 유저의 레포지토리 리스트를 가져오는 유스케이스를 각각 따로 만들어 향후 단일로도 사용할 수 있게 구현했습니다.
- 이후 이 유스케이스들을 조합하여 유저 상세 정보를 얻을 수 있는 유스케이스를 만들어 사용했습니다.
- flow의 combine을 사용해 조합하여 구현했습니다.

## Screenshot
<img src="https://github.com/user-attachments/assets/175dcad8-b545-419c-a3e5-271666caa153" width="300" /> 
<img src="https://github.com/user-attachments/assets/624fe5ce-f064-4310-a289-4f015720a438" width="300" />


